### PR TITLE
Fix: Correct import path for ProjectContext in Header.tsx

### DIFF
--- a/src/renderer/components/Header.tsx
+++ b/src/renderer/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useState, Fragment } from 'react';
-import { useProject } from '../../contexts/ProjectContext';
+import { useProject } from '../contexts/ProjectContext';
 import ProjectForm from './project/ProjectForm'; // Ensure this path is correct
 import { Menu, Transition } from '@headlessui/react'; // Using Headless UI for dropdown
 import { ChevronDownIcon, FolderPlusIcon, FolderIcon } from '@heroicons/react/20/solid'; // Example icons


### PR DESCRIPTION
Changed the relative import path in `src/renderer/components/Header.tsx` from `../../contexts/ProjectContext` to `../contexts/ProjectContext` to accurately point to the ProjectContext module located in `src/renderer/contexts/`.